### PR TITLE
Add decoder public function specs

### DIFF
--- a/lib/bencoding.ex
+++ b/lib/bencoding.ex
@@ -3,11 +3,13 @@ defmodule Bencoding do
   Bencoding encoder/decoder module
   """
 
-  def decode(string) do
+  @spec decode(binary()) :: {:error, binary()} | {:ok, any()}
+  def decode(string) when is_binary(string) do
     Bencoding.Decoder.decode(string)
   end
 
-  def decode!(string) do
+  @spec decode!(binary()) :: any()
+  def decode!(string) when is_binary(string) do
     { :ok, result } = Bencoding.Decoder.decode(string)
 
     result

--- a/lib/bencoding/decoder.ex
+++ b/lib/bencoding/decoder.ex
@@ -3,7 +3,8 @@ defmodule Bencoding.Decoder do
   Bencoding's decoder module
   """
 
-  def decode(string) do
+  @spec decode(binary()) :: {:error, binary()} | {:ok, any()}
+  def decode(string) when is_binary(string) do
     try do
       { :ok, result, _ } = string
       |> _get_bencode


### PR DESCRIPTION
- Add `@spec` blocks for the public modules' functions.
- Enforce decoder's input is a binary