### PR TITLE
Fix string decoding

### DIFF
--- a/lib/bencoding/decoder.ex
+++ b/lib/bencoding/decoder.ex
@@ -69,15 +69,12 @@ defmodule Bencoding.Decoder do
   defp _do_decode_string(data) when is_binary(data) do
     try do
       [len, content] = String.split(data, ":", parts: 2)
-      len = String.to_integer(len)
+      { len, "" } = Integer.parse(len)
 
-      if String.length(content) < len do
-        throw(:error)
-      else
-        { :ok, String.slice(content, 0, len), String.slice(content, len, String.length(content)) }
-      end
+      << string :: bytes-size(len), rest :: binary >> = content
+      { :ok, string, rest }
     rescue
-      ArgumentError -> throw(:error)
+      MatchError -> throw(:error)
     end
   end
 end


### PR DESCRIPTION
Strings should be handled as UTF-8 encoded data. The `String` module functions that were being used work on grahemes and that led to incorrect character counts and string manipulation.